### PR TITLE
Updating to 2.1/beta scheduler compatibility

### DIFF
--- a/LearnedTag/LearnedTag.py
+++ b/LearnedTag/LearnedTag.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Copyright: Luminous Spice <luminous.spice@gmail.com>
+# License: GNU AGPL, version 3 or later; http://www.gnu.org/copyleft/agpl.html
+#
+# This simple Add-on automatically adds a tag on your mature notes after the review.
+# GitHub: https://github.com/luminousspice/anki-addons/
+
+#This is a simple modification of the above add-on to tag a card and fill a field (if you have such a field), which represents knowing a card well enough to switch templates, reverse it, study the content elsewhere, etc. 
+#By default the setting is 7 but I think anywhere under two weeks should work well. You can use 'selective card generation' (see Anki manual) to automatically create new cards of a certain template style when the field is filled.
+
+from anki.hooks import wrap
+from anki.sched import Scheduler
+from aqt import mw
+
+# Threshold learned interval
+threshold = 10 # days
+
+# Tag string for learned note
+LearnedTag = u"Learned"
+def learnedCheck(self, card, ease):
+    f = card.note()
+    if (card.ivl >= threshold):
+        f.addTag(LearnedTag)
+        if 'Learned' in mw.col.models.fieldNames(f.model()): # if field exists
+            if not f[ 'Learned' ]: # if field is empty
+                f[ 'Learned' ] = 'Yes'
+    f.flush()
+    return True
+
+Scheduler.answerCard = wrap(Scheduler.answerCard, learnedCheck)
+from anki.schedv2 import Scheduler as SchedulerV2
+SchedulerV2.answerCard = wrap(SchedulerV2.answerCard, learnedCheck)

--- a/LearnedTag/__init__.py
+++ b/LearnedTag/__init__.py
@@ -1,0 +1,1 @@
+from . import LearnedTag

--- a/MatureTag/MatureTag.py
+++ b/MatureTag/MatureTag.py
@@ -23,3 +23,5 @@ def matureCheck(self, card, ease):
     return True
 
 Scheduler.answerCard = wrap(Scheduler.answerCard, matureCheck)
+from anki.schedv2 import Scheduler as SchedulerV2
+SchedulerV2.answerCard = wrap(SchedulerV2.answerCard, matureCheck)


### PR DESCRIPTION
- Learned variant is just modified from your version originally on Anki addon site. A few things changed (interval now 10 but that's just my preference). Added beta scheduler compatibility & added __init__.py file for 2.1 compatibility in general. 

- Mature only updated to have beta scheduler compatibility.